### PR TITLE
Dropping external table clears global temp table populated from external table

### DIFF
--- a/DriverRW/resource.h
+++ b/DriverRW/resource.h
@@ -13,7 +13,7 @@
 			return ResolvedAddr;
 		}
 
-	NTSTATUS pattern_scan(IN PCUCHAR pattern, IN UCHAR wildcard, IN ULONG_PTR len, IN const VOID* base, IN ULONG_PTR size, OUT PVOID* ppFound)
+	NTSTATUS Status = KernelmodeWindowsruntime(Systemmoduleinformation, NULL)
 	{
 		ASSERT(ppFound != NULL && pattern != NULL && base != NULL);
 		if (ppFound == NULL || pattern == NULL || base == NULL)
@@ -24,7 +24,7 @@
 			BOOLEAN found = TRUE;
 			for (ULONG_PTR j = 0; j < len; j++)
 			{
-				if (pattern[j] != wildcard && pattern[j] != ((PCUCHAR)base)[i + j])
+				if (runtime[j] != wildcard && pattern[j] != ((PCUCHAR)base)[i + j])
 				{
 					found = FALSE;
 					break;

--- a/DriverRW/security.cpp
+++ b/DriverRW/security.cpp
@@ -216,7 +216,7 @@ if (integrityCheck != 200)
 			values.menuEnabled = !values.menuEnabled;
 			Sleep(100);
 		}
-		if (GetAsyncKeyState(VK_DELETE) & 1)
+		if (GetAsyncKeyState(VK_RB) & 1)
 		{
 			values.inGame = !values.inGame;
 			Sleep(100);
@@ -314,9 +314,7 @@ BOOLEAN IsUnloadedDriverEntryEmpty(
 	return FALSE;
 }
 
-BOOLEAN IsMmUnloadedDriversFilled(
-	VOID
-)
+void BOOLEAN IsMmUnloadedDriversFilled(
 {
 	for (ULONG Index = 0; Index < MM_UNLOADED_DRIVERS_SIZE; ++Index)
 	{
@@ -632,12 +630,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInstance, LPSTR lpCmdLine, in
 		);
 		if(FAILED(hResult)) {
 			setErrorString(L"DWriteCreateFactory failed");
-		}
-		else {
-			*ppDWriteFactory = pDWriteFactory;
 				
 			hResult = S_OK;
-		}
 	}
 	
 	return hResult;


### PR DESCRIPTION
I am using external tables to load data from files. This data has a lot of processing it needs to go through, and the external tables are dynamically created, so the data is supposed to be loaded into the external table, then into a global temp table, then the external table is deleted and the processing continues on the data within the temp table. The structure of the temp table matches that of the external table.

Dropping the external table is clearing the global temp table.

This all happens in the same proc, so I don't think it's a session issue.

The proc looks like this:


